### PR TITLE
fixed double encoding issues

### DIFF
--- a/src/DataURI/Data.php
+++ b/src/DataURI/Data.php
@@ -216,16 +216,6 @@ class Data
 
     $data = file_get_contents($file->getPathname());
     
-    if ($binaryData && ! $data = base64_encode($data))
-    {
-      throw new InvalidData('base64 encoding failed');
-    }
-    
-    if(!$binaryData)
-    {
-      $data = rawurlencode($data);
-    }
-    
     $dataURI = new static($data, $file->getMimeType(), array(), $len);
     
     $dataURI->setBinaryData($binaryData);

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -119,7 +119,7 @@ class DataTest extends PHPUnit_Framework_TestCase
     $dataURI = DataURI\Data::buildFromFile($file, true);
     $this->assertInstanceOf('DataURI\Data', $dataURI);
     $this->assertEquals('image/png', $dataURI->getMimeType());
-    $this->assertEquals(file_get_contents($file), base64_decode($dataURI->getData()));
+    $this->assertEquals(file_get_contents($file), $dataURI->getData());
   }
 
   public function testFileNotFound()


### PR DESCRIPTION
When loading data from binary files, the files are double-encoded (base64, rawurlencode) after being output by the dumper. This PR fixes this by only encoding the content when dumping the file (which makes sense as far is I see it).
