### PR TITLE
adjusting the parser and adding tests for formats with dots and pluses (...

### DIFF
--- a/src/DataURI/Parser.php
+++ b/src/DataURI/Parser.php
@@ -38,7 +38,7 @@ class Parser
      * offset #2 Parameters
      * offset #3 Datas
      */
-    const DATA_URI_REGEXP = '/data:([a-zA-Z-\/]+)([a-zA-Z0-9-_;=]+)?,(.*)/';
+    const DATA_URI_REGEXP = '/data:([a-zA-Z-\/]+)([a-zA-Z0-9-_;=.+]+)?,(.*)/';
 
     /**
      * Parse a data URI and return a DataUri\Data

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -36,7 +36,9 @@ class ParserTest extends PHPUnit_Framework_TestCase
             "data:image/png;base64," . $b64,
             "data:image/png;paramName=paramValue;base64," . $b64,
             "data:text/plain;charset=utf-8,%23%24%25",
-            "data:application/vnd-xxx-query,select_vcount,fcol_from_fieldtable/local"
+            "data:application/vnd-xxx-query,select_vcount,fcol_from_fieldtable/local",
+			"data:image/svg+xml;base64," . $b64,
+			"data:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;base64," . $b64
         );
 
         $dataURI = DataURI\Parser::parse($tests[0]);


### PR DESCRIPTION
...such as the ones in the test)

Following everything who I've read in the other pull request, adding the tests and adding an extra character (the plus sign), who allows to parse svg docs as well (image/svg+xml).
