### PR TITLE
Pin sami/sami package version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "symfony/http-foundation": "~2.0|~3.0"
   },
   "require-dev": {
-    "sami/sami": "dev-master",
+    "sami/sami": "^3.3",
     "ext-curl": "*",
     "phpunit/phpunit": "^4.0|^5.0"
   },


### PR DESCRIPTION
composer install fails because of the sami/sami dev-master

see https://travis-ci.org/alchemy-fr/PHP-dataURI/jobs/175051238

```
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - Installation request for sami/sami dev-master -> satisfiable by sami/sami[dev-master].
    - sami/sami dev-master requires php >=5.5.9 -> your PHP version (5.3.29) does not satisfy that 
```

This PR fix the problem by pinning a sami/sami version.

