### PR TITLE
Fixed test input & added symfony 4.0 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   }],
   "require": {
     "php": ">=5.3.2",
-    "symfony/http-foundation": "~2.0|~3.0"
+    "symfony/http-foundation": "~2.0|~3.0|~4.0"
   },
   "require-dev": {
     "sami/sami": "^3.3",

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -121,7 +121,7 @@ class DataTest extends PHPUnit_Framework_TestCase
 
     public function testBuildFromUrl()
     {
-        $url = 'http://www.alchemy.fr/images/header_03.png';
+        $url = 'http://via.placeholder.com/350x150';
         $dataURI = DataURI\Data::buildFromUrl($url);
         $this->assertInstanceOf('DataURI\Data', $dataURI);
         $this->assertEquals('image/png', $dataURI->getMimeType());


### PR DESCRIPTION
There is missing image file from source so i replaced that with placeholder one to pass the tests.

Lumen 5.6 requires symfony version 4.0 and this package has been used in twig extension.
This will fix twig data-uri extension package (that depends on this package) that allows to use that extension while running it on lumen 5.6