### PR TITLE
Fix Symfony 5 Incopatybility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   }],
   "require": {
     "php": ">=5.3.2",
-    "symfony/http-foundation": "~2.0|~3.0|~4.0"
+    "symfony/http-foundation": "~2.0|~3.0|~4.0|~5.0"
   },
   "require-dev": {
     "sami/sami": "^3.3",


### PR DESCRIPTION
Fixing error:

```
  Problem 1
    - Installation request for data-uri/data-uri ^0.2.5 -> satisfiable by data-uri/data-uri[0.2.5].
    - data-uri/data-uri 0.2.5 requires symfony/http-foundation ~2.0|~3.0|~4.0 -> no matching package found.
```